### PR TITLE
Fix start button not starting run

### DIFF
--- a/script.js
+++ b/script.js
@@ -18,7 +18,11 @@ let hero = {
 let enemies = [];
 let enemyTimer = 0;
 let backgroundOffset = 0;
-let gameState = 'running';
+// Start the game in upgrade state so the player must press the
+// "Começar" button to begin a run. Previously the game state was set
+// to running on load, which meant clicking the start button appeared
+// to do nothing.
+let gameState = 'upgrade';
 
 function heroDamage() {
     return 10 + swordLevel * 5;
@@ -180,8 +184,10 @@ document.getElementById('startRun').addEventListener('click', () => {
     hero.maxHealth = baseHealth + armorLevel * 20;
     hero.health = hero.maxHealth;
     enemies = [];
+    enemyTimer = 0;
     closeMenu();
 });
 
-updateMenuText();
+// Show the upgrade menu on load and wait for the player to start the run.
+openMenu();
 loop();


### PR DESCRIPTION
## Summary
- Initialize game in upgrade state so clicking **Começar** starts a run
- Reset enemy timer and display upgrade menu on load

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899601f9f188325b26a9119ab990e1a