### PR TITLE
Fix upgrade menu lingering over game

### DIFF
--- a/style.css
+++ b/style.css
@@ -25,6 +25,10 @@ canvas {
     color: #fff;
 }
 
+#upgradeMenu.hidden {
+    display: none;
+}
+
 .hidden {
     display: none;
 }


### PR DESCRIPTION
## Summary
- Ensure the upgrade menu hides when starting a run by overriding menu styling

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689961dd61f88325b6913cb1e207431f